### PR TITLE
fixed overlap of buttons in left menu

### DIFF
--- a/www/master.mustache.html
+++ b/www/master.mustache.html
@@ -46,7 +46,7 @@
           {{/topic_range}}
         </ul>
       </div>
-      <div class="sidebar-helper" style="position: absolute; bottom: 0;">
+      <div class="sidebar-helper" style="bottom: 0;">
         <ul class="sidebar-nav">
           <li><a class="selected" data-placement="right" title="Help" href="javascript:toggleSearch()"><strong>?</strong></a></li>
           <li><a href="#" class="selected" data-placement="right" title="Usage" data-toggle="modal" data-target="#rightsModal"><strong>&copy;</strong></a></li>


### PR DESCRIPTION
The help and topic buttons at the left were overlapping when there were more than 10 topic buttons like at this link: http://inphodata.cogs.indiana.edu/ap/100/?doc=AP880322-0211. The position for the help and copyright buttons needed to not be absolute. So after deleting that, the problem was resolved.