### PR TITLE
Issues/271

### DIFF
--- a/www/bars.mustache.html
+++ b/www/bars.mustache.html
@@ -673,9 +673,11 @@ d3.json(url, function(error, data) {
         .attr("class", "axis_label")
         .attr("dy", "-.45em")
         .attr("dx", "5em")
-        .attr("font-size", "10px")
+        .attr("font-size", "9.5px")
         .style("text-anchor", "start")
-        .text("ordered by P( T | " + docid + " )");
+        .style("overflow-wrap", "normal")
+        .text("ordered by proportion of T in " + (docid ? "focal document" : "corpus"));
+        //.text("ordered by P( T | " + docid + " )");
 
     d3.select(window).on('resize', resize);
   

--- a/www/bars.mustache.html
+++ b/www/bars.mustache.html
@@ -677,7 +677,6 @@ d3.json(url, function(error, data) {
         .style("text-anchor", "start")
         .style("overflow-wrap", "normal")
         .text("ordered by proportion of T in " + (docid ? "focal document" : "corpus"));
-        //.text("ordered by P( T | " + docid + " )");
 
     d3.select(window).on('resize', resize);
   


### PR DESCRIPTION
The conditional probability above the legend for the topics said undefined when it was in topic focus mode. Also, in document focus mode, it showed the whole document name which ended up being cut off in a lot of cases. So, now instead of showing undefined for topic focus mode, it says "sorted by proportion in corpus" and for document focus mode it says "sorted by proportion in focal document." Also resolves #270 