### PR TITLE
Issues/272

### DIFF
--- a/www/bars.mustache.html
+++ b/www/bars.mustache.html
@@ -77,11 +77,12 @@
     else {
       topDoc.style.display = 'block';
       if (roottopic == null) {
-        if (mainDoc.value.length > 16) {
-          $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "...");
-        } else {
-          $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17));
-          }
+        //if (mainDoc.value.length > 16) {
+          //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "...");
+        //} else {
+          //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17));
+        //}
+          $("#focalDoc").text("Top 40 documents most similar to the focal document");
       } else {
         $("#focalDoc").text("Top 40 documents most similar to topic " + roottopic);
       }
@@ -565,11 +566,12 @@ d3.json(url, function(error, data) {
           //Handles when to update the descriptor based off which mode it is in and what topic bar was clicked on.
           //Indicates whether the model is sorted by proportion of a specific topic or not.
           if (roottopic == null) {
-            if (mainDoc.value.length > 16) {
-              $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d.name);
-            } else {
-              $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d.name);
-            }
+            //if (mainDoc.value.length > 16) {
+              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d.name);
+            //} else {
+              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d.name);
+            //}
+            $("#focalDoc").text("Top 40 documents most similar to the focal document sorted by proportion of topic " + d.name);
           } else if (roottopic == d.name) {
             topDoc.style.display = 'none';
             $("#focalDoc").text("Top 40 documents most similar to topic " + roottopic);
@@ -625,11 +627,12 @@ d3.json(url, function(error, data) {
           //Handles when to update the descriptor based off which mode it is in and what topic bar was clicked on.
           //Indicates whether the model is sorted by proportion of a specific topic or not.
           if (roottopic == null) {
-             if (mainDoc.value.length > 16) {
-              $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d);
-            } else {
-              $("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d);
-            }
+             //if (mainDoc.value.length > 16) {
+              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d);
+            //} else {
+              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d);
+            //}
+            $("#focalDoc").text("Top 40 documents most similar to the focal document sorted by proportion of topic " + d);
           } else if (roottopic == d) {
             topDoc.style.display = 'none';
             $("#focalDoc").text("Top 40 documents most similar to topic " + roottopic);

--- a/www/bars.mustache.html
+++ b/www/bars.mustache.html
@@ -77,11 +77,6 @@
     else {
       topDoc.style.display = 'block';
       if (roottopic == null) {
-        //if (mainDoc.value.length > 16) {
-          //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "...");
-        //} else {
-          //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17));
-        //}
           $("#focalDoc").text("Top 40 documents most similar to the focal document");
       } else {
         $("#focalDoc").text("Top 40 documents most similar to topic " + roottopic);
@@ -566,11 +561,6 @@ d3.json(url, function(error, data) {
           //Handles when to update the descriptor based off which mode it is in and what topic bar was clicked on.
           //Indicates whether the model is sorted by proportion of a specific topic or not.
           if (roottopic == null) {
-            //if (mainDoc.value.length > 16) {
-              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d.name);
-            //} else {
-              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d.name);
-            //}
             $("#focalDoc").text("Top 40 documents most similar to the focal document sorted by proportion of topic " + d.name);
           } else if (roottopic == d.name) {
             topDoc.style.display = 'none';
@@ -627,11 +617,6 @@ d3.json(url, function(error, data) {
           //Handles when to update the descriptor based off which mode it is in and what topic bar was clicked on.
           //Indicates whether the model is sorted by proportion of a specific topic or not.
           if (roottopic == null) {
-             //if (mainDoc.value.length > 16) {
-              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + "... sorted by proportion of topic " + d);
-            //} else {
-              //$("#focalDoc").text("Top 40 documents most similar to " + mainDoc.value.slice(0, 17) + " sorted by proportion of topic " + d);
-            //}
             $("#focalDoc").text("Top 40 documents most similar to the focal document sorted by proportion of topic " + d);
           } else if (roottopic == d) {
             topDoc.style.display = 'none';


### PR DESCRIPTION
Instead of truncating the document name now for the descriptors, it just shows "focal document" now, which looks cleaner too.