### PR TITLE
Implemented temporary fix for default topic number issue

### DIFF
--- a/topicexplorer/config.py
+++ b/topicexplorer/config.py
@@ -24,7 +24,7 @@ def read(filename):
         'label_module': None,
         'fulltext': False,
         'pdf' : False,
-        'topics': [],
+        'topics': '[20, 40, 60, 80]',
         'cluster': None,
         'corpus_desc' : None,
         'home_link' : '/',

--- a/topicexplorer/train.py
+++ b/topicexplorer/train.py
@@ -217,6 +217,7 @@ def main(args):
         from vsm.corpus import Corpus
 
     if args.k is None:
+        #TODO: Clean up default topic numbers
         try:
             if config.get("main", "topics"):
                 default = ' '.join(map(str, eval(config.get("main", "topics"))))


### PR DESCRIPTION
Changed `'topics': []` in `config.py` to `'topics': "[20, 40, 60, 80]"` to get rid of chances that the topicexplorer would default to `[]` when training.