### PR TITLE
fixed typo in topicexplorer/update.py

### DIFF
--- a/topicexplorer/update.py
+++ b/topicexplorer/update.py
@@ -185,7 +185,7 @@ def update(args=None):
                     return
 
             try:
-                cmd = ['pip', 'install', f'topicexplorer=={pypi_version}', '--no-cache-dir']
+                cmd = ['pip', 'install', 'topicexplorer=={pypi_version}', '--no-cache-dir']
                 subprocess.check_call(cmd, shell=False)
             except CalledProcessError:
                 print("ERROR: Update did not comlete installation.\n")


### PR DESCRIPTION
On line 188 of topicexplorer/update.py, there was an extra character 'f', that caused the file to fail to compile during any topicexplorer command. I removed this character, and now the files are able to compile. 